### PR TITLE
ARM: dts: sun8i: Enable sun8i-emac on the NanoPi NEO

### DIFF
--- a/arch/arm/boot/dts/sun8i-h3-nanopi-neo.dts
+++ b/arch/arm/boot/dts/sun8i-h3-nanopi-neo.dts
@@ -53,6 +53,7 @@
 
 	aliases {
 		serial0 = &uart0;
+		ethernet0 = &emac;
 	};
 
 	chosen {
@@ -121,5 +122,12 @@
 
 &usbphy {
 	/* USB VBUS is always on */
+	status = "okay";
+};
+
+&emac {
+	phy-handle = <&int_mii_phy>;
+	phy-mode = "mii";
+	allwinner,leds-active-low;
 	status = "okay";
 };


### PR DESCRIPTION
Signed-off-by: Damjan Marion <damjan.marion@gmail.com>