### PR TITLE
Crypto: sun8i-ce (PRNG): preventing memory leaks

### DIFF
--- a/drivers/crypto/allwinner/sun8i-ce/sun8i-ce-prng.c
+++ b/drivers/crypto/allwinner/sun8i-ce/sun8i-ce-prng.c
@@ -85,8 +85,10 @@ fail:
 		memcpy(dst, data, len);
 		dst += len;
 		dlen -= len;
-		if (dlen > 4 && antifail++ < 10)
+		if (dlen > 4 && antifail++ < 10) {
+			kfree(ss->chanlist[flow].next_iv);
 			goto rebegin;
+		}
 	}
 	memzero_explicit(data, PRNG_DATA_SIZE);
 	kfree(data);


### PR DESCRIPTION
When the sun8i_ce_prng_generate is called multiple times, a memory leak occurs. This is due to switching between flows. Each time the flow is switched, ss-> chanlist [flow] occurs .next_iv = kmalloc (PRNG_SEED_SIZE, GFP_KERNEL);
But the memory is freed once when the function sun8i_ce_prng_generate is completed. This results in a memory leak. To prevent memory leaks, I suggest releasing the allocated memory before each flow switch.